### PR TITLE
Feature/#5-Cors-설정-추가

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/global/config/WebConfig.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/global/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.seoul_competition.senior_jobtraining.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**")
+        .allowedOrigins("*")
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH");
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #5 

## 📝 Description

- CORS(Cross-Origin Resource Sharing)은 웹 브라우저에서 다른 도메인의 API를 사용할 때, 보안을 위해 설정된 보안 정책
- 설정해야 하는 이유 
  - CORS란 도메인이 다른 서버끼리 리소스를 주고 받는 정책
  -  기본적으로 웹 브라우저의 기본 정책은 `Same-Origin(동일 출처 정책)`으로 되어 있어 다른 서버와의 리소스 공유를 허용하지 않는다.
  - 현재 상황으로 비유하면 백엔드 서버 < - > 프론트엔드 서버가 리소스를 주고 받을 때 cors 설정을 하지 않으면 포트가 다르기 때문에 `origin`이 달라 CORS 위반 문제가 발생

- CORS의 기본 동작 원리
  - 브라우저는 다른 `origin`으로 요청을 보낼 때 `origin` 헤더의 자신의 `origin`을 설정
  - 서버로부터 응답을 받으면 응답의 `Access-Controle-Allow-Origin` 헤더에 설정된 Origin의 목록에 요청에 `Origin` 헤더 값이 포함되는지 검사

## ⭐️ Review
- 참고 문서
  - https://developer.mozilla.org/ko/docs/Web/HTTP/CORS
  - https://letsmakemyselfprogrammer.tistory.com/89