### PR TITLE
Feat/#7 swagger 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.0.5'
-	id 'io.spring.dependency-management' version '1.1.0'
+    id 'java'
+    id 'org.springframework.boot' version '3.0.5'
+    id 'io.spring.dependency-management' version '1.1.0'
 }
 
 group = 'com.seoul_competition'
@@ -9,24 +9,26 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '17'
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/global/config/SwaggerConfig.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/global/config/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package com.seoul_competition.senior_jobtraining.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    return new OpenAPI()
+        .components(new Components())
+        .info(apiInfo());
+  }
+
+  private Info apiInfo() {
+    return new Info()
+        .title("어르신 교육 지원 웹사이트 API");
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #7 

## 📝 Description

- `swagger`를 적용하기 위해 처음에는 `springfox-boot-starter`를 추가하기로 함
- 이후 적용을 해보면서 spring boot 3.xx 버전에서는 `springfox-boot-starter`가 적용되지 않는 것을 찾음
- spring boot 3.xx 버전에는 `springdoc-openapi-starter-webmvc-ui`를 추가해야 `swagger`를 적용할 수 있음
- 동시에 `spring-boot-starter-validation`를 추가해야 함
  - 스프링 부트 3.xx 버전에서 `springdoc-openapi-starter-webmvc-ui`를 추가하면, 해당 스타터 패키지에서 자동으로 javax.validation 패키지를 사용하여 객체 유효성 검증 기능을 활성화하려고 시도
  -  패키지를 찾을 수 없는 경우, 예를 들어 spring-boot-starter-validation을 추가하지 않은 경우, jakarta.validation.NoProviderFoundException과 같은 예외가 발생
  - http://{host}:{port}/swagger-ui/index.html 로 접속

### 참고자료
- https://stackoverflow.com/questions/74614369/how-to-run-swagger-3-on-spring-boot-3

## ⭐️ Review
- 새로운 지식을 얻었습니다. 오!~