### PR TITLE
Feature/post관련 entity repository생성

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/SeniorJobtrainingApplication.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/SeniorJobtrainingApplication.java
@@ -2,12 +2,14 @@ package com.seoul_competition.senior_jobtraining;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SeniorJobtrainingApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SeniorJobtrainingApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(SeniorJobtrainingApplication.class, args);
+  }
 
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/dao/CommentRepository.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/dao/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.seoul_competition.senior_jobtraining.domain.comment.dao;
+
+import com.seoul_competition.senior_jobtraining.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/entity/Comment.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/entity/Comment.java
@@ -33,9 +33,12 @@ public class Comment {
   @JoinColumn(name = "post_id", nullable = false)
   private Post post;
 
+  @Column(nullable = false)
   private String nickname;
 
+  @Column(nullable = false)
   private String password;
 
+  @Column(nullable = false)
   private String content;
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/entity/Comment.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/entity/Comment.java
@@ -1,0 +1,41 @@
+package com.seoul_competition.senior_jobtraining.domain.comment.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import com.seoul_competition.senior_jobtraining.domain.post.entity.Post;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+@Table(name = "comment")
+public class Comment {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  @Column(name = "id", nullable = false)
+  private Long id;
+
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "post_id", nullable = false)
+  private Post post;
+
+  private String nickname;
+
+  private String password;
+
+  private String content;
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/entity/Comment.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/entity/Comment.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -41,4 +42,21 @@ public class Comment {
 
   @Column(nullable = false)
   private String content;
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (!(obj instanceof Comment other)) {
+      return false;
+    }
+    return Objects.equals(this.id, other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.id);
+  }
+
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/entity/Comment.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/entity/Comment.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.Objects;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -42,6 +43,14 @@ public class Comment {
 
   @Column(nullable = false)
   private String content;
+
+  @Builder
+  private Comment(Post post, String nickname, String password, String content) {
+    this.post = post;
+    this.nickname = nickname;
+    this.password = password;
+    this.content = content;
+  }
 
   @Override
   public boolean equals(Object obj) {

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/dao/PostRepository.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/dao/PostRepository.java
@@ -1,0 +1,8 @@
+package com.seoul_competition.senior_jobtraining.domain.post.dao;
+
+import com.seoul_competition.senior_jobtraining.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/entity/Post.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/entity/Post.java
@@ -1,0 +1,49 @@
+package com.seoul_competition.senior_jobtraining.domain.post.entity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+@Table(name = "post")
+public class Post {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  private String nickname;
+
+  private String password;
+
+  private String title;
+
+  @Lob
+  private String content;
+
+  @CreatedDate
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+
+  private Long hits;
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/entity/Post.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/entity/Post.java
@@ -55,7 +55,7 @@ public class Post {
   @Column(nullable = false)
   private LocalDateTime updatedAt;
 
-  @Column(nullable = false)
+  @Column(columnDefinition = "BIGINT default 0", nullable = false)
   private Long hits;
 
   @OneToMany(mappedBy = "post", cascade = REMOVE)

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/entity/Post.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/entity/Post.java
@@ -1,16 +1,21 @@
 package com.seoul_competition.senior_jobtraining.domain.post.entity;
 
+import static jakarta.persistence.CascadeType.REMOVE;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import com.seoul_competition.senior_jobtraining.domain.comment.entity.Comment;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -28,13 +33,17 @@ public class Post {
   @GeneratedValue(strategy = IDENTITY)
   private Long id;
 
+  @Column(nullable = false)
   private String nickname;
 
+  @Column(nullable = false)
   private String password;
 
+  @Column(nullable = false)
   private String title;
 
   @Lob
+  @Column(nullable = false)
   private String content;
 
   @CreatedDate
@@ -45,5 +54,9 @@ public class Post {
   @Column(nullable = false)
   private LocalDateTime updatedAt;
 
+  @Column(nullable = false)
   private Long hits;
+
+  @OneToMany(mappedBy = "post", cascade = REMOVE)
+  private final List<Comment> comments = new ArrayList<>();
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/entity/Post.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/entity/Post.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -59,4 +60,21 @@ public class Post {
 
   @OneToMany(mappedBy = "post", cascade = REMOVE)
   private final List<Comment> comments = new ArrayList<>();
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (!(obj instanceof Post other)) {
+      return false;
+    }
+    return Objects.equals(this.id, other.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.id);
+  }
+
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/entity/Post.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/entity/Post.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -60,6 +61,18 @@ public class Post {
 
   @OneToMany(mappedBy = "post", cascade = REMOVE)
   private final List<Comment> comments = new ArrayList<>();
+
+  @Builder
+  private Post(String nickname, String password, String title, String content,
+      LocalDateTime createdAt, LocalDateTime updatedAt, Long hits) {
+    this.nickname = nickname;
+    this.password = password;
+    this.title = title;
+    this.content = content;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
+    this.hits = hits;
+  }
 
   @Override
   public boolean equals(Object obj) {


### PR DESCRIPTION
## 🔥 Related Issue

close: #9 

## 📝 Description

**Post**
- Comment Entity와 양방향 연관관계를 맺어주었습니다. 
- `cascade`를 `REMOVE`를 설정하여, Post 엔티티를 삭제할 때 연관된 Comment 엔티티도 함께 삭제하도록 설정하였습니다. 
- 이렇게 설정하면 Comment 엔티티를 삭제할 필요 없이 한 번에 모두 삭제할 수 있습니다.
```java
  @OneToMany(mappedBy = "post", cascade = REMOVE)
  private final List<Comment> comments = new ArrayList<>();
```

**Comment**
- Post 엔티티와 Comment 엔티티 간에 다대일 관계가 성립합니다.
```java
  @ManyToOne(fetch = LAZY)
  @JoinColumn(name = "post_id", nullable = false)
  private Post post;
```

**Auditing**
- JPA의 auditing기능을 사용하기 위해 각 엔티티에 `EntityListeners(AuditingEntityListener.class)` 어노테이션을 설정하였습니다.
- Main클래스 위에 `EnableJpaAuditing` 어노테이션을 추가하였습니다.

## ⭐️ Review
아직 완벽하게 완성한 부분이 아니라 계속 수정해야될 것 같네요.