### PR TITLE
feat: Comment Entity에 생성일, 수정일 추가

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/entity/Comment.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/entity/Comment.java
@@ -13,10 +13,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
@@ -43,6 +46,14 @@ public class Comment {
 
   @Column(nullable = false)
   private String content;
+
+  @CreatedDate
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
 
   @Builder
   private Comment(Post post, String nickname, String password, String content) {


### PR DESCRIPTION
## 🔥 Related Issue

close: #9 

## 📝 Description

- 생성일, 수정일을 댓글 Entity에는 추가해주지 않았습니다.

## ⭐️ Review
빼먹었었네요.