### PR TITLE
Feature/#14 api education 매핑

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/api/EducationController.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/api/EducationController.java
@@ -18,9 +18,14 @@ public class EducationController {
 
   private final EducationService educationService;
 
+  private boolean first = true;
+
   @GetMapping
   public ResponseEntity<EducationListResponse> getAllEducations() {
-    educationService.saveAll();
+    if (first) {
+      educationService.saveAll();
+      first = false;
+    }
     EducationListResponse response = educationService.findAll();
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/api/EducationController.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/api/EducationController.java
@@ -20,6 +20,7 @@ public class EducationController {
 
   @GetMapping
   public ResponseEntity<EducationListResponse> getAllEducations() {
+    educationService.saveAll();
     EducationListResponse response = educationService.findAll();
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/EducationService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/EducationService.java
@@ -3,9 +3,14 @@ package com.seoul_competition.senior_jobtraining.domain.education.application;
 import com.seoul_competition.senior_jobtraining.domain.education.dao.EducationRepository;
 import com.seoul_competition.senior_jobtraining.domain.education.dto.response.EducationListResponse;
 import com.seoul_competition.senior_jobtraining.domain.education.dto.response.EducationResponse;
+import com.seoul_competition.senior_jobtraining.domain.education.entity.Education;
+import com.seoul_competition.senior_jobtraining.global.external.openApi.education.FiftyApi;
+import com.seoul_competition.senior_jobtraining.global.external.openApi.education.SeniorApi;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class EducationService {
 
   private final EducationRepository educationRepository;
+  private final FiftyApi fiftyApi;
+  private final SeniorApi seniorApi;
 
   public EducationListResponse findAll() {
     return new EducationListResponse(entityToResponse());
@@ -28,5 +35,47 @@ public class EducationService {
 
   public EducationResponse findById(Long id) {
     return new EducationResponse(educationRepository.findById(id).get());
+  }
+
+  @Transactional
+  public void saveAll() {
+    saveFifty(fiftyApi.getInfoArr());
+    saveSenior(seniorApi.getInfoArr());
+  }
+
+  private void saveFifty(JSONArray infoArr) {
+    for (int i = 0; i < infoArr.size(); i++) {
+      JSONObject jsonObject = (JSONObject) infoArr.get(i);
+      Education education = Education.builder()
+          .name((String) jsonObject.get("LCT_NM"))
+          .state((String) jsonObject.get("LCT_STAT"))
+          .url((String) jsonObject.get("CR_URL"))
+          .price(Integer.parseInt((String) jsonObject.get("LCT_COST")))
+          .capacity(Integer.parseInt((String) jsonObject.get("CR_PPL_STAT")))
+          .registerStart((String) jsonObject.get("REG_STDE"))
+          .registerEnd((String) jsonObject.get("REG_EDDE"))
+          .educationStart((String) jsonObject.get("CR_STDE"))
+          .educationEnd((String) jsonObject.get("CR_EDDE"))
+          .build();
+      educationRepository.save(education);
+    }
+  }
+
+  private void saveSenior(JSONArray infoArr) {
+    for (int i = 0; i < infoArr.size(); i++) {
+      JSONObject jsonObject = (JSONObject) infoArr.get(i);
+      Education education = Education.builder()
+          .name((String) jsonObject.get("SUBJECT"))
+          .state((String) jsonObject.get("APPLY_STATE"))
+          .url((String) jsonObject.get("VIEWDETAIL"))
+          .price(Integer.parseInt((String) jsonObject.get("REGISTCOST")))
+          .capacity(Integer.parseInt((String) jsonObject.get("REGISTPEOPLE")))
+          .registerStart((String) jsonObject.get("APPLICATIONSTARTDATE"))
+          .registerEnd((String) jsonObject.get("APPLICATIONENDDATE"))
+          .educationStart((String) jsonObject.get("STARTDATE"))
+          .educationEnd((String) jsonObject.get("ENDDATE"))
+          .build();
+      educationRepository.save(education);
+    }
   }
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/EducationService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/EducationService.java
@@ -22,6 +22,8 @@ public class EducationService {
   private final EducationRepository educationRepository;
   private final FiftyApi fiftyApi;
   private final SeniorApi seniorApi;
+  private final static String BEFORE_WAITING_CONTENT = "접수중";
+  private final static String AFTER_WAITING_CONTENT = "수강신청중";
 
   public EducationListResponse findAll() {
     return new EducationListResponse(entityToResponse());
@@ -64,18 +66,29 @@ public class EducationService {
   private void saveSenior(JSONArray infoArr) {
     for (int i = 0; i < infoArr.size(); i++) {
       JSONObject jsonObject = (JSONObject) infoArr.get(i);
+
+      String applyState = getCommonApplyState(jsonObject);
+
       Education education = Education.builder()
           .name((String) jsonObject.get("SUBJECT"))
-          .state((String) jsonObject.get("APPLY_STATE"))
+          .state(applyState)
           .url((String) jsonObject.get("VIEWDETAIL"))
           .price(Integer.parseInt((String) jsonObject.get("REGISTCOST")))
           .capacity(Integer.parseInt((String) jsonObject.get("REGISTPEOPLE")))
-          .registerStart((String) jsonObject.get("APPLICATIONSTARTDATE"))
-          .registerEnd((String) jsonObject.get("APPLICATIONENDDATE"))
-          .educationStart((String) jsonObject.get("STARTDATE"))
-          .educationEnd((String) jsonObject.get("ENDDATE"))
+          .registerStart(((String) jsonObject.get("APPLICATIONSTARTDATE")).replaceAll("-", "."))
+          .registerEnd(((String) jsonObject.get("APPLICATIONENDDATE")).replaceAll("-", "."))
+          .educationStart(((String) jsonObject.get("STARTDATE")).replaceAll("-", "."))
+          .educationEnd(((String) jsonObject.get("ENDDATE")).replaceAll("-", "."))
           .build();
       educationRepository.save(education);
     }
+  }
+
+  private static String getCommonApplyState(JSONObject jsonObject) {
+    String applyState = (String) jsonObject.get("APPLY_STATE");
+    if (applyState.equals(BEFORE_WAITING_CONTENT)) {
+      applyState = AFTER_WAITING_CONTENT;
+    }
+    return applyState;
   }
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationListResponse.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationListResponse.java
@@ -2,6 +2,6 @@ package com.seoul_competition.senior_jobtraining.domain.education.dto.response;
 
 import java.util.List;
 
-public record EducationListResponse(List<EducationResponse> educationList) {
+public record EducationListResponse(List<EducationResponse> data) {
 
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationResponse.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationResponse.java
@@ -7,15 +7,15 @@ import lombok.Getter;
 @Getter
 public class EducationResponse {
 
-  private int price;
-  private int capacity;
   private String name;
   private String state;
-  private String url;
+  private int price;
+  private int capacity;
   private String registerStart;
   private String registerEnd;
   private String educationStart;
   private String educationEnd;
+  private String url;
 
   public EducationResponse(Education education) {
     this.name = education.getName();

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationResponse.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 public class EducationResponse {
 
+  private Long id;
   private String name;
   private String state;
   private int price;
@@ -18,6 +19,7 @@ public class EducationResponse {
   private String url;
 
   public EducationResponse(Education education) {
+    this.id = education.getId();
     this.name = education.getName();
     this.state = education.getState();
     this.url = education.getUrl();

--- a/src/main/java/com/seoul_competition/senior_jobtraining/global/external/openApi/education/FiftyApi.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/global/external/openApi/education/FiftyApi.java
@@ -1,5 +1,6 @@
 package com.seoul_competition.senior_jobtraining.global.external.openApi.education;
 
+import jakarta.annotation.PostConstruct;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -26,7 +27,7 @@ public class FiftyApi {
   private JSONObject subResult;
   private JSONArray infoArr;
 
-
+  @PostConstruct
   public void getJson() {
     try {
       URL url = new URL(String.format(OPENAPI_URL, key));

--- a/src/main/java/com/seoul_competition/senior_jobtraining/global/external/openApi/education/SeniorApi.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/global/external/openApi/education/SeniorApi.java
@@ -1,5 +1,6 @@
 package com.seoul_competition.senior_jobtraining.global.external.openApi.education;
 
+import jakarta.annotation.PostConstruct;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
@@ -25,7 +26,7 @@ public class SeniorApi {
   private JSONObject subResult;
   private JSONArray infoArr;
 
-
+  @PostConstruct
   public void getJson() {
     try {
       URL url = new URL(String.format(OPENAPI_URL, key));

--- a/src/test/java/com/seoul_competition/senior_jobtraining/domain/education/api/EducationControllerTest.java
+++ b/src/test/java/com/seoul_competition/senior_jobtraining/domain/education/api/EducationControllerTest.java
@@ -1,0 +1,40 @@
+package com.seoul_competition.senior_jobtraining.domain.education.api;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.seoul_competition.senior_jobtraining.domain.education.dto.response.EducationListResponse;
+import com.seoul_competition.senior_jobtraining.global.external.openApi.education.FiftyApi;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class EducationControllerTest {
+
+  @Autowired
+  EducationController educationController;
+
+  @Autowired
+  FiftyApi fiftyApi;
+
+  @Test
+  @DisplayName("모든 교육을 조회할 때, http가 정상적으로 200을 반환했는지 테스트")
+  public void should_httpStatusOk_when_getAllEducations() {
+    assertThat(educationController.getAllEducations().getStatusCode()).isEqualTo(
+        HttpStatus.OK);
+
+  }
+
+  @Test
+  @DisplayName("모든 교육을 조회할 때, http Body에 들어가는지 테스트")
+  public void should_saveResponseBody_when_getAllEducations() {
+    assertThat(
+        educationController.getAllEducations().getBody().toString().length() > 1000).isTrue();
+  }
+
+}

--- a/src/test/java/com/seoul_competition/senior_jobtraining/domain/education/dao/EducationRepositoryTest.java
+++ b/src/test/java/com/seoul_competition/senior_jobtraining/domain/education/dao/EducationRepositoryTest.java
@@ -10,7 +10,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @SpringBootTest
 class EducationRepositoryTest {
 


### PR DESCRIPTION
## 🔥 Related Issue

close: #14 

## 📝 Description

education에 두 외부 API에서 가져온 Json 데이터로, 매핑 시켰습니다.

## ⭐️ Review

두 API의 같은 말이지만, 다른 형식의 코멘트라서, 한 API에 코멘트를 맞췄습니다.
하지만 Senior쪽에 '수강신청예정' 부분의 데이터가 없어, 해당 코멘트를 찾지못해, 구현을 하지 못했습니다. 
추후 새 데이터로, 코멘트가 나오면, 수정하고, 만약 안나오면 else를 통해 구현하겠습니다.

처음 가져온건 그렇다고 쳐도,  새로운 데이터에 대하여 어떻게 매핑할지 잘 모르겠어서, 추후 구현해보겠습니다.