### PR TITLE
Feature/#75 본래id 및 생성 시간 컬럼 구현

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/convenience/EducationFiftyService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/convenience/EducationFiftyService.java
@@ -57,6 +57,7 @@ public class EducationFiftyService {
           .educationStart((String) jsonObject.get("CR_STDE"))
           .educationEnd((String) jsonObject.get("CR_EDDE"))
           .hits(0L)
+          .originId(Integer.parseInt((String) jsonObject.get("LCT_NO")))
           .build();
       educationRepository.save(education);
     }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/convenience/EducationSeniorService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/convenience/EducationSeniorService.java
@@ -38,6 +38,7 @@ public class EducationSeniorService {
           .educationStart(((String) jsonObject.get("STARTDATE")).replaceAll("-", "."))
           .educationEnd(((String) jsonObject.get("ENDDATE")).replaceAll("-", "."))
           .hits(0L)
+          .originId(Integer.parseInt((String) jsonObject.get("IDX")))
           .build();
       educationRepository.save(education);
     }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/entity/Education.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/entity/Education.java
@@ -62,10 +62,13 @@ public class Education {
   @Column(nullable = false)
   private LocalDateTime createdAt;
 
+  @Column(name = "origin_id", nullable = false)
+  private int originId;
+
   @Builder
   public Education(String name, String state, String url, String price, int capacity,
       String registerStart, String registerEnd, String educationStart,
-      String educationEnd, Long hits) {
+      String educationEnd, Long hits, int originId) {
 
     this.name = name;
     this.state = state;
@@ -77,6 +80,7 @@ public class Education {
     this.educationStart = educationStart;
     this.educationEnd = educationEnd;
     this.hits = hits;
+    this.originId = originId;
   }
 
   public void hitsPlus() {

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/entity/Education.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/entity/Education.java
@@ -4,22 +4,27 @@ import com.seoul_competition.senior_jobtraining.domain.review.entity.Review;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.lang.String;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "education")
 public class Education {
 
@@ -52,6 +57,10 @@ public class Education {
 
   @OneToMany(mappedBy = "education", cascade = CascadeType.REMOVE)
   private List<Review> reviews = new ArrayList<>();
+
+  @CreatedDate
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
 
   @Builder
   public Education(String name, String state, String url, String price, int capacity,


### PR DESCRIPTION
## 🔥 Related Issue

close: #75 

## 📝 Description

Ai측에서 모델링을 할 때, 필요한 컬럼들을 추가 시켰습니다.
외부 api의 본래의 ID를 `origin_id` 컬럼으로 매핑을 시켰습니다.
`@CreatedDate`로 쉽게 생성 시간만 구현을 하였습니다.

## ⭐️ Review

남기고 싶은 내용을 설명해주세요.