### PR TITLE
Feature/#81 게시글 댓글 수정 api 변경

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/api/CommentController.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/api/CommentController.java
@@ -54,4 +54,12 @@ public class CommentController {
     commentService.delete(commentId, password.get("password"));
     return ResponseEntity.noContent().build();
   }
+
+  @Operation(summary = "비밀번호 일치", description = "비밀번호가 일치하는지 확인")
+  @PostMapping("/{commentId}/matchCheck")
+  public ResponseEntity<Void> matchCheck(@PathVariable Long commentId,
+      @RequestBody Map<String, String> password) {
+    commentService.matchCheck(commentId, password.get("password"));
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/application/CommentService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/application/CommentService.java
@@ -7,8 +7,10 @@ import com.seoul_competition.senior_jobtraining.domain.comment.entity.Comment;
 import com.seoul_competition.senior_jobtraining.domain.post.dao.PostRepository;
 import com.seoul_competition.senior_jobtraining.domain.post.entity.Post;
 import com.seoul_competition.senior_jobtraining.global.error.ErrorCode;
+import com.seoul_competition.senior_jobtraining.global.error.exception.BusinessException;
 import com.seoul_competition.senior_jobtraining.global.error.exception.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,14 +31,12 @@ public class CommentService {
 
   @Transactional
   public void update(Long commentId, CommentUpdateReqDto reqDto) {
-    postRepository.findById(reqDto.postId())
-        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_EXISTS));
 
     Comment comment = commentRepository.findById(commentId)
         .orElseThrow(() -> new EntityNotFoundException(
             ErrorCode.COMMENT_NOT_EXISTS));
-    comment.checkPassword(reqDto.password());
 
+    comment.checkPassword(reqDto.password());
     comment.update(reqDto.content());
   }
 
@@ -46,5 +46,15 @@ public class CommentService {
         .orElseThrow(() -> new EntityNotFoundException(ErrorCode.COMMENT_NOT_EXISTS));
     comment.checkPassword(password);
     commentRepository.delete(comment);
+  }
+
+  public void matchCheck(Long commentId, String password) {
+    if (StringUtils.isBlank(password)) {
+      throw new BusinessException(ErrorCode.PASSWORD_EMPTY);
+    }
+    Comment comment = commentRepository.findById(commentId).orElseThrow(
+        () -> new EntityNotFoundException(
+            ErrorCode.COMMENT_NOT_EXISTS));
+    comment.checkPassword(password);
   }
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/dto/request/CommentUpdateReqDto.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/comment/dto/request/CommentUpdateReqDto.java
@@ -1,14 +1,13 @@
 package com.seoul_competition.senior_jobtraining.domain.comment.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public record CommentUpdateReqDto(
-    @NotNull(message = "게시글 번호를 입력해주세요.") Long postId,
+
     @NotBlank(message = "비밀번호를 입력해주세요.") String password,
     @NotBlank(message = "내용이 비어있습니다.") String content) {
 
-  public static CommentUpdateReqDto of(long postId, String password, String updatedContent) {
-    return new CommentUpdateReqDto(postId, password, updatedContent);
+  public static CommentUpdateReqDto of(String password, String updatedContent) {
+    return new CommentUpdateReqDto(password, updatedContent);
   }
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/application/PostService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/application/PostService.java
@@ -50,6 +50,8 @@ public class PostService {
         () -> new EntityNotFoundException(
             ErrorCode.POST_NOT_EXISTS));
 
+    post.checkPassword(reqDto.password());
+
     post.update(reqDto.nickname(), reqDto.title(), reqDto.content());
   }
 

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/dto/request/PostUpdateReqDto.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/post/dto/request/PostUpdateReqDto.java
@@ -3,11 +3,14 @@ package com.seoul_competition.senior_jobtraining.domain.post.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 public record PostUpdateReqDto(
+
     @NotBlank(message = "닉네임을 입력해주세요.") String nickname,
+    @NotBlank(message = "비밀번호를 입력해주세요.") String password,
     @NotBlank(message = "게시글 제목을 입력해주세요.") String title,
     @NotBlank(message = "게시글 본문을 입력해주세요.") String content) {
 
-  public static PostUpdateReqDto of(String nickname, String title, String content) {
-    return new PostUpdateReqDto(nickname, title, content);
+  public static PostUpdateReqDto of(String nickname, String password, String title,
+      String content) {
+    return new PostUpdateReqDto(nickname, password, title, content);
   }
 }

--- a/src/test/java/com/seoul_competition/senior_jobtraining/domain/comment/api/CommentControllerTest.java
+++ b/src/test/java/com/seoul_competition/senior_jobtraining/domain/comment/api/CommentControllerTest.java
@@ -100,7 +100,7 @@ class CommentControllerTest {
   void givenCommentInfo_whenUpdating_thenUpdatesComment() throws Exception {
     // given
     Long commentId = 1L;
-    CommentUpdateReqDto reqDto = CommentUpdateReqDto.of(1L, "1234", "updated content");
+    CommentUpdateReqDto reqDto = CommentUpdateReqDto.of("1234", "updated content");
 
     // when
     ResultActions resultActions = mvc.perform(put("/api/v1/comments/" + commentId, 1L)
@@ -111,33 +111,18 @@ class CommentControllerTest {
     resultActions.andExpect(status().isCreated());
   }
 
-  @DisplayName("[PUT] 댓글 수정 - 실패: 존재하지 않는 게시물")
-  @Test
-  void givenNonExistentPostId_whenUpdating_thenReturnsBadRequest() throws Exception {
-    // given
-    Long commentId = 1L;
-    CommentUpdateReqDto reqDto = CommentUpdateReqDto.of(999L, "1234", "updated content");
-
-    // when
-    ResultActions resultActions = mvc.perform(put("/api/v1/comments/" + commentId, 1L)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(new ObjectMapper().writeValueAsString(reqDto)));
-
-    // then
-    resultActions.andExpect(status().isBadRequest());
-  }
-
   @DisplayName("[PUT] 댓글 수정 - 실패: 올바르지 않은 비밀번호")
   @Test
   void givenIncorrectPassword_whenUpdating_thenReturnsBadRequest() throws Exception {
     // given
     Long commentId = 1L;
-    CommentUpdateReqDto reqDto = CommentUpdateReqDto.of(1L, "incorrectpassword", "updated content");
+    CommentUpdateReqDto reqDto = CommentUpdateReqDto.of("incorrectpassword", "updated content");
 
     // when
-    ResultActions resultActions = mvc.perform(put("/api/v1/comments/" + commentId, 1L)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(new ObjectMapper().writeValueAsString(reqDto)));
+    ResultActions resultActions = mvc.perform(
+        post("/api/v1/comments/" + commentId + "/matchCheck", 1L)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(new ObjectMapper().writeValueAsString(reqDto)));
 
     // then
     resultActions.andExpect(status().isBadRequest());

--- a/src/test/java/com/seoul_competition/senior_jobtraining/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/seoul_competition/senior_jobtraining/domain/comment/application/CommentServiceTest.java
@@ -73,9 +73,8 @@ class CommentServiceTest {
     // Given
     Long commentId = 1L;
     Comment comment = createComment(commentId, "password", "content");
-    CommentUpdateReqDto dto = createCommentUpdateReqDto(1L, "password",
+    CommentUpdateReqDto dto = createCommentUpdateReqDto("password",
         "updated content");
-    given(postRepository.findById(dto.postId())).willReturn(Optional.ofNullable(createPost()));
     given(commentRepository.findById(commentId)).willReturn(Optional.ofNullable(comment));
     Mockito.lenient().when(commentRepository.save(any(Comment.class))).thenReturn(null);
 
@@ -83,7 +82,6 @@ class CommentServiceTest {
     commentService.update(commentId, dto);
 
     // Then
-    then(postRepository).should().findById(dto.postId());
     then(commentRepository).should().findById(commentId);
     assertThat(comment.getContent()).isEqualTo(dto.content());
   }
@@ -93,9 +91,8 @@ class CommentServiceTest {
   void givenNonexistentCommentId_whenUpdatingPostComment_thenThrowsEntityNotFoundException() {
     // Given
     Long nonExistentCommentId = 999L;
-    CommentUpdateReqDto dto = createCommentUpdateReqDto(1L, "password",
+    CommentUpdateReqDto dto = createCommentUpdateReqDto("password",
         "updated content");
-    given(postRepository.findById(dto.postId())).willReturn(Optional.ofNullable(createPost()));
     given(commentRepository.findById(nonExistentCommentId)).willReturn(Optional.empty());
 
     // When, Then
@@ -109,9 +106,8 @@ class CommentServiceTest {
     // Given
     Long commentId = 1L;
     Comment comment = createComment(commentId, "password", "content");
-    CommentUpdateReqDto dto = createCommentUpdateReqDto(1L, "wrong_password",
+    CommentUpdateReqDto dto = createCommentUpdateReqDto("wrong_password",
         "updated content");
-    given(postRepository.findById(dto.postId())).willReturn(Optional.ofNullable(createPost()));
     given(commentRepository.findById(commentId)).willReturn(Optional.ofNullable(comment));
 
     // When, Then
@@ -166,9 +162,9 @@ class CommentServiceTest {
   }
 
 
-  private CommentUpdateReqDto createCommentUpdateReqDto(long postId, String password,
+  private CommentUpdateReqDto createCommentUpdateReqDto(String password,
       String updatedContent) {
-    return CommentUpdateReqDto.of(postId, password, updatedContent);
+    return CommentUpdateReqDto.of(password, updatedContent);
   }
 
   private Comment createComment(Long commentId, String password, String content) {

--- a/src/test/java/com/seoul_competition/senior_jobtraining/domain/post/api/PostControllerTest.java
+++ b/src/test/java/com/seoul_competition/senior_jobtraining/domain/post/api/PostControllerTest.java
@@ -91,7 +91,7 @@ class PostControllerTest {
   void givenUpdatedPostInfo_whenRequesting_thenUpdateNewPost() throws Exception {
     // Given
     long postId = 1L;
-    PostUpdateReqDto postUpdateReqDto = new PostUpdateReqDto("nickname수정", "title수정",
+    PostUpdateReqDto postUpdateReqDto = new PostUpdateReqDto("nickname수정", "1234", "title수정",
         "content수정");
     String requestBody = om.writeValueAsString(postUpdateReqDto);
 
@@ -104,14 +104,14 @@ class PostControllerTest {
     resultActions.andExpect(status().isCreated());
   }
 
-  @DisplayName("[PUT] 게시글 수정 - 비밀번호 불일치")
+  @DisplayName("[POST] 게시글 수정 - 비밀번호 불일치")
   @Test
   void givenUpdatedPostInfo_whenRequesting_thenThrowBusinessException() throws Exception {
     // Given
     long postId = 1L;
-    PostUpdateReqDto postUpdateReqDto = new PostUpdateReqDto("nickname", "title수정",
+    PostUpdateReqDto postUpdateReqDto = new PostUpdateReqDto("nickname", "123123123", "title수정",
         "content수정");
-    String requestBody = om.writeValueAsString(Map.of("password", "123123123"));
+    String requestBody = om.writeValueAsString(Map.of("password", postUpdateReqDto.password()));
 
     // When
     ResultActions resultActions = mvc.perform(

--- a/src/test/java/com/seoul_competition/senior_jobtraining/domain/post/application/PostServiceTest.java
+++ b/src/test/java/com/seoul_competition/senior_jobtraining/domain/post/application/PostServiceTest.java
@@ -75,7 +75,7 @@ class PostServiceTest {
   void givenModifiedPostInfo_whenUpdatingPost_thenUpdatesPost() {
     // Given
     Post post = createPost();
-    PostUpdateReqDto dto = createPostUpdateReqDto("nickname", "새 타이틀", "새 내용");
+    PostUpdateReqDto dto = createPostUpdateReqDto("nickname", "1234", "새 타이틀", "새 내용");
     given(postRepository.findById(anyLong())).willReturn(Optional.ofNullable(post));
 
     // When
@@ -105,9 +105,9 @@ class PostServiceTest {
   }
 
 
-  private PostUpdateReqDto createPostUpdateReqDto(String nickname, String title,
+  private PostUpdateReqDto createPostUpdateReqDto(String nickname, String password, String title,
       String content) {
-    return PostUpdateReqDto.of(nickname, title, content);
+    return PostUpdateReqDto.of(nickname, password, title, content);
   }
 
   private Post createPost() {


### PR DESCRIPTION
## 🔥 Related Issue

close: #81 

## 📝 Description

- 기존 게시글 수정 로직을 롤백하고, 비밀번호 체크 부분은 남겨두었습니다.
- 게시글 댓글 비밀번호 체크 로직을 만들어두어 수정하기 전에 진입을 막을 수 있도록 하였습니다. 