### PR TITLE
Feature/#80 검색 조회 기록 엔티티 생성

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/user/dao/UserDetailRepository.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/user/dao/UserDetailRepository.java
@@ -1,0 +1,8 @@
+package com.seoul_competition.senior_jobtraining.domain.user.dao;
+
+import com.seoul_competition.senior_jobtraining.domain.user.entity.UserDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserDetailRepository extends JpaRepository<UserDetail, Long> {
+
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/user/dao/UserSearchRepository.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/user/dao/UserSearchRepository.java
@@ -1,0 +1,8 @@
+package com.seoul_competition.senior_jobtraining.domain.user.dao;
+
+import com.seoul_competition.senior_jobtraining.domain.user.entity.UserSearch;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserSearchRepository extends JpaRepository<UserSearch, Long> {
+
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/user/entity/BoardCategory.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/user/entity/BoardCategory.java
@@ -1,0 +1,16 @@
+package com.seoul_competition.senior_jobtraining.domain.user.entity;
+
+public enum BoardCategory {
+  FREE(0),
+  EDUCATION(1);
+
+  private final int value;
+
+  BoardCategory(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/user/entity/UserDetail.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/user/entity/UserDetail.java
@@ -1,0 +1,80 @@
+package com.seoul_competition.senior_jobtraining.domain.user.entity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+@Table(name = "userDetail")
+public class UserDetail {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private BoardCategory category;
+
+  @Column(nullable = false)
+  private String gender;
+
+  @Column(nullable = false)
+  private String age;
+
+  @Column(nullable = false)
+  private String location;
+
+  @Column(nullable = false)
+  private String interest;
+
+  @Column(nullable = false)
+  private Long postId;
+
+  @CreatedDate
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @Builder
+  public UserDetail(BoardCategory boardCategory, String gender, String age, String location,
+      String interest, Long postId) {
+    this.category = boardCategory;
+    this.gender = gender;
+    this.age = age;
+    this.location = location;
+    this.interest = interest;
+    this.postId = postId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UserDetail that = (UserDetail) o;
+    return Objects.equals(getId(), that.getId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId());
+  }
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/user/entity/UserSearch.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/user/entity/UserSearch.java
@@ -1,0 +1,81 @@
+package com.seoul_competition.senior_jobtraining.domain.user.entity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = PROTECTED)
+@Entity
+@Table(name = "userSearch")
+public class UserSearch {
+
+  @Id
+  @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private BoardCategory category;
+
+  @Column(nullable = false)
+  private String gender;
+
+  @Column(nullable = false)
+  private String age;
+
+  @Column(nullable = false)
+  private String location;
+
+  @Column(nullable = false)
+  private String interest;
+
+  @Column(nullable = false)
+  private String keyword;
+
+  @CreatedDate
+  @Column(nullable = false)
+  private LocalDateTime createdAt;
+
+  @Builder
+  public UserSearch(BoardCategory category, String gender, String age, String location,
+      String interest,
+      String keyword) {
+    this.category = category;
+    this.gender = gender;
+    this.age = age;
+    this.location = location;
+    this.interest = interest;
+    this.keyword = keyword;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UserSearch that = (UserSearch) o;
+    return Objects.equals(getId(), that.getId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId());
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #80 

## 📝 Description

- 검색 기록을 저장하는 엔티티, 조회 기록을 저장하는 엔티티를 생성했습니다.
- 각각의 `repository` 도 생성하였습니다.

## ⭐️ Review
- 공통으로 쓰이는 파일이라, Enum 형식의 파일을 만들어 두었습니다. 0(자유 게시글), 1(교육 게시글)