### PR TITLE
chore: queryDsl 설치 및 generated(QType) 깃 무시 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 
 ### yml ###
 src/main/resources/application.yml
+
+### queryDsl ###
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1'
     //Json parser
+
+    //Querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 🔥 Related Issue

close: #89 

## 📝 Description

queryDsl를 설치하는데 여러가지 방법이 있습니다.
저는 Gradle 의존성 추가 방식을 택하였고, 어노테이션들도 추가하였습니다.

또한 QType이 자동으로 생성되는 generated폴더를 `.ignore` 해주었습니다.

## ⭐️ Review

최근엔 Kotlin DSL이 있다고 하네요..