### PR TITLE
Feature/#95 교육 컬럼 리팩토링

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/api/EducationController.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/api/EducationController.java
@@ -1,9 +1,9 @@
 package com.seoul_competition.senior_jobtraining.domain.education.api;
 
 import com.seoul_competition.senior_jobtraining.domain.education.application.EducationService;
+import com.seoul_competition.senior_jobtraining.domain.education.dto.request.EducationSearchReqDto;
 import com.seoul_competition.senior_jobtraining.domain.education.dto.response.EducationDetailResDto;
 import com.seoul_competition.senior_jobtraining.domain.education.dto.response.EducationListPageResponse;
-import com.seoul_competition.senior_jobtraining.domain.education.dto.response.EducationResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
@@ -11,9 +11,9 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -28,17 +28,12 @@ public class EducationController {
   @GetMapping
   public ResponseEntity<EducationListPageResponse> getAllEducations(
       @PageableDefault(sort = "status", size = 20, direction = Direction.DESC) Pageable pageable,
-      @RequestParam(value = "name", required = false) String name) {
+      @ModelAttribute EducationSearchReqDto reqDto) {
     if (first) {
       educationService.saveAll();
       first = false;
     }
-    EducationListPageResponse response;
-    if (name == null) {
-      response = educationService.findAllByPage(pageable);
-    } else {
-      response = educationService.findAllByName(pageable, name);
-    }
+    EducationListPageResponse response = educationService.getEducations(pageable, reqDto);
     return ResponseEntity.status(HttpStatus.OK).body(response);
   }
 

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/EducationService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/EducationService.java
@@ -55,12 +55,12 @@ public class EducationService {
           .numberPath(Integer.class, "education.price")
           .lt(reqDto.maxPrice()));
     }
-    if (reqDto.startDate() != null) {
-      builder.and(education.educationStart.gt(reqDto.startDate()));
-    }
-    if (reqDto.endDate() != null) {
-      builder.and(education.educationEnd.lt(reqDto.endDate()));
-    }
+//    if (reqDto.startDate() != null) {
+//      builder.and(education.educationStart.gt(reqDto.startDate()));
+//    }
+//    if (reqDto.endDate() != null) {
+//      builder.and(education.educationEnd.lt(reqDto.endDate()));
+//    }
 
     Page<Education> educationPage = educationRepository.findAll(builder, pageable);
 

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/EducationService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/EducationService.java
@@ -36,7 +36,7 @@ public class EducationService {
     checkPageNumber(pageable, educationPage);
 
     return new EducationListPageResponse(entityToResponse(educationPage),
-        educationPage.getTotalPages() - 1, pageable.getPageNumber());
+        educationPage.getTotalPages() - 1, pageable.getPageNumber(), educationPage.getTotalElements());
   }
 
   public EducationListPageResponse findAllByName(Pageable pageable, String name) {
@@ -46,7 +46,7 @@ public class EducationService {
     checkPageNumber(pageable, educationPage);
 
     return new EducationListPageResponse(entityToResponse(educationPage),
-        educationPage.getTotalPages() - 1, pageable.getPageNumber());
+        educationPage.getTotalPages() - 1, pageable.getPageNumber(), educationPage.getTotalElements());
   }
 
   private void checkPageNumber(Pageable pageable, Page<Education> educationPage) {

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/convenience/EducationFiftyService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/convenience/EducationFiftyService.java
@@ -23,8 +23,6 @@ public class EducationFiftyService {
   private static int startPage = 0;
   private static int endPage = 999;
   private static int increaseUnit = 1000;
-  private static DecimalFormat decimalFormat = new DecimalFormat("###,###");
-
 
   @Transactional
   public void saveFifty() {
@@ -46,9 +44,7 @@ public class EducationFiftyService {
           .name((String) jsonObject.get("LCT_NM"))
           .status((String) jsonObject.get("LCT_STAT"))
           .url((String) jsonObject.get("CR_URL"))
-          .price(decimalFormat.format(Integer.parseInt(
-              (String) jsonObject.get("LCT_COST") != "" ? (String) jsonObject.get("LCT_COST")
-                  : "0")))
+          .price(Integer.parseInt((String) jsonObject.get("LCT_COST")))
           .capacity(Integer.parseInt(
               (String) jsonObject.get("CR_PPL_STAT") != "" ? (String) jsonObject.get(
                   "CR_PPL_STAT") : "0"))

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/convenience/EducationFiftyService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/convenience/EducationFiftyService.java
@@ -5,6 +5,8 @@ import com.seoul_competition.senior_jobtraining.domain.education.entity.Educatio
 import com.seoul_competition.senior_jobtraining.global.error.BusinessException;
 import com.seoul_competition.senior_jobtraining.global.external.openApi.education.FiftyApi;
 import java.text.DecimalFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.JSONArray;
@@ -38,6 +40,8 @@ public class EducationFiftyService {
   }
 
   private void saveInfoArr(JSONArray infoArr) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
     for (int i = 0; i < infoArr.size(); i++) {
       JSONObject jsonObject = (JSONObject) infoArr.get(i);
       Education education = Education.builder()
@@ -48,10 +52,10 @@ public class EducationFiftyService {
           .capacity(Integer.parseInt(
               (String) jsonObject.get("CR_PPL_STAT") != "" ? (String) jsonObject.get(
                   "CR_PPL_STAT") : "0"))
-          .registerStart((String) jsonObject.get("REG_STDE"))
-          .registerEnd((String) jsonObject.get("REG_EDDE"))
-          .educationStart((String) jsonObject.get("CR_STDE"))
-          .educationEnd((String) jsonObject.get("CR_EDDE"))
+          .registerStart(LocalDate.parse((String) jsonObject.get("REG_STDE"), formatter))
+          .registerEnd(LocalDate.parse((String) jsonObject.get("REG_EDDE"), formatter))
+          .educationStart(LocalDate.parse((String) jsonObject.get("CR_STDE"), formatter))
+          .educationEnd(LocalDate.parse((String) jsonObject.get("CR_EDDE"), formatter))
           .hits(0L)
           .originId(Integer.parseInt((String) jsonObject.get("LCT_NO")))
           .build();

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/convenience/EducationSeniorService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/convenience/EducationSeniorService.java
@@ -18,7 +18,6 @@ public class EducationSeniorService {
 
   private final static String BEFORE_WAITING_CONTENT = "접수중";
   private final static String AFTER_WAITING_CONTENT = "수강신청중";
-  private static DecimalFormat decimalFormat = new DecimalFormat("###,###");
 
   @Transactional
   public void saveSenior(JSONArray infoArr) {
@@ -31,7 +30,7 @@ public class EducationSeniorService {
           .name((String) jsonObject.get("SUBJECT"))
           .status(applyState)
           .url((String) jsonObject.get("VIEWDETAIL"))
-          .price(decimalFormat.format(Integer.parseInt((String) jsonObject.get("REGISTCOST"))))
+          .price((Integer.parseInt((String) jsonObject.get("REGISTCOST"))))
           .capacity(Integer.parseInt((String) jsonObject.get("REGISTPEOPLE")))
           .registerStart(((String) jsonObject.get("APPLICATIONSTARTDATE")).replaceAll("-", "."))
           .registerEnd(((String) jsonObject.get("APPLICATIONENDDATE")).replaceAll("-", "."))

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/convenience/EducationSeniorService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/convenience/EducationSeniorService.java
@@ -3,6 +3,8 @@ package com.seoul_competition.senior_jobtraining.domain.education.application.co
 import com.seoul_competition.senior_jobtraining.domain.education.dao.EducationRepository;
 import com.seoul_competition.senior_jobtraining.domain.education.entity.Education;
 import java.text.DecimalFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -19,8 +21,11 @@ public class EducationSeniorService {
   private final static String BEFORE_WAITING_CONTENT = "접수중";
   private final static String AFTER_WAITING_CONTENT = "수강신청중";
 
+
   @Transactional
   public void saveSenior(JSONArray infoArr) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
     for (int i = 0; i < infoArr.size(); i++) {
       JSONObject jsonObject = (JSONObject) infoArr.get(i);
 
@@ -32,10 +37,19 @@ public class EducationSeniorService {
           .url((String) jsonObject.get("VIEWDETAIL"))
           .price((Integer.parseInt((String) jsonObject.get("REGISTCOST"))))
           .capacity(Integer.parseInt((String) jsonObject.get("REGISTPEOPLE")))
-          .registerStart(((String) jsonObject.get("APPLICATIONSTARTDATE")).replaceAll("-", "."))
-          .registerEnd(((String) jsonObject.get("APPLICATIONENDDATE")).replaceAll("-", "."))
-          .educationStart(((String) jsonObject.get("STARTDATE")).replaceAll("-", "."))
-          .educationEnd(((String) jsonObject.get("ENDDATE")).replaceAll("-", "."))
+          .registerStart(
+              LocalDate.parse(
+                  ((String) jsonObject.get("APPLICATIONSTARTDATE")).replaceAll("-", "."),
+                  formatter))
+          .registerEnd(
+              LocalDate.parse(
+                  ((String) jsonObject.get("APPLICATIONENDDATE")).replaceAll("-", "."), formatter))
+          .educationStart(
+              LocalDate.parse(((String) jsonObject.get("STARTDATE")).replaceAll("-", "."),
+                  formatter))
+          .educationEnd(
+              LocalDate.parse(((String) jsonObject.get("ENDDATE")).replaceAll("-", "."),
+                  formatter))
           .hits(0L)
           .originId(Integer.parseInt((String) jsonObject.get("IDX")))
           .build();

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dao/EducationRepository.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dao/EducationRepository.java
@@ -4,8 +4,11 @@ import com.seoul_competition.senior_jobtraining.domain.education.entity.Educatio
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
-public interface EducationRepository extends JpaRepository<Education, Long> {
+public interface EducationRepository extends JpaRepository<Education, Long>,
+    QuerydslPredicateExecutor<Education> {
 
   Page<Education> findByNameContainingOrderByStatusDesc(Pageable pageable, String name);
+
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/request/EducationSearchReqDto.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/request/EducationSearchReqDto.java
@@ -1,0 +1,11 @@
+package com.seoul_competition.senior_jobtraining.domain.education.dto.request;
+
+public record EducationSearchReqDto(
+    String name,
+    String status,
+    String startDate,
+    String endDate,
+    Integer minPrice,
+    Integer maxPrice) {
+
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationDetailResDto.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationDetailResDto.java
@@ -1,8 +1,10 @@
 package com.seoul_competition.senior_jobtraining.domain.education.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.seoul_competition.senior_jobtraining.domain.education.entity.Education;
 import com.seoul_competition.senior_jobtraining.domain.review.dto.response.ReviewResDto;
 import java.text.DecimalFormat;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -13,10 +15,14 @@ public record EducationDetailResDto(
 
     String price,
     Integer capacity,
-    String registerStart,
-    String registerEnd,
-    String educationStart,
-    String educationEnd,
+    @JsonFormat(pattern = "yyyy.MM.dd")
+    LocalDate registerStart,
+    @JsonFormat(pattern = "yyyy.MM.dd")
+    LocalDate registerEnd,
+    @JsonFormat(pattern = "yyyy.MM.dd")
+    LocalDate educationStart,
+    @JsonFormat(pattern = "yyyy.MM.dd")
+    LocalDate educationEnd,
     String url,
     Long hits,
     List<ReviewResDto> reviews) {

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationDetailResDto.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationDetailResDto.java
@@ -2,6 +2,7 @@ package com.seoul_competition.senior_jobtraining.domain.education.dto.response;
 
 import com.seoul_competition.senior_jobtraining.domain.education.entity.Education;
 import com.seoul_competition.senior_jobtraining.domain.review.dto.response.ReviewResDto;
+import java.text.DecimalFormat;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,7 +22,8 @@ public record EducationDetailResDto(
     List<ReviewResDto> reviews) {
 
   public EducationDetailResDto(Education education) {
-    this(education.getId(), education.getName(), education.getStatus(), education.getPrice(),
+    this(education.getId(), education.getName(), education.getStatus(),
+        new DecimalFormat("###,###").format(education.getPrice()),
         education.getCapacity(), education.getRegisterStart(), education.getRegisterEnd(),
         education.getEducationStart(), education.getEducationEnd(), education.getUrl(),
         education.getHits(),

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationDetailResDto.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationDetailResDto.java
@@ -12,7 +12,7 @@ public record EducationDetailResDto(
     String status,
 
     String price,
-    int capacity,
+    Integer capacity,
     String registerStart,
     String registerEnd,
     String educationStart,

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationListPageResponse.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationListPageResponse.java
@@ -2,6 +2,7 @@ package com.seoul_competition.senior_jobtraining.domain.education.dto.response;
 
 import java.util.List;
 
-public record EducationListPageResponse(List<EducationResponse> data, int totalPages, int currentPage) {
+public record EducationListPageResponse(List<EducationResponse> data, int totalPages,
+                                        int currentPage, Long totalCounts) {
 
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationResponse.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationResponse.java
@@ -1,6 +1,7 @@
 package com.seoul_competition.senior_jobtraining.domain.education.dto.response;
 
 import com.seoul_competition.senior_jobtraining.domain.education.entity.Education;
+import java.text.DecimalFormat;
 import lombok.Getter;
 
 
@@ -26,7 +27,7 @@ public class EducationResponse {
     this.name = education.getName();
     this.status = education.getStatus();
     this.url = education.getUrl();
-    this.price = education.getPrice();
+    this.price = new DecimalFormat("###,###").format(education.getPrice());
     this.capacity = education.getCapacity();
     this.registerStart = education.getRegisterStart();
     this.registerEnd = education.getRegisterEnd();

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationResponse.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationResponse.java
@@ -13,7 +13,7 @@ public class EducationResponse {
   private String status;
 
   private String price;
-  private int capacity;
+  private Integer capacity;
   private String registerStart;
   private String registerEnd;
   private String educationStart;

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationResponse.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/EducationResponse.java
@@ -1,7 +1,9 @@
 package com.seoul_competition.senior_jobtraining.domain.education.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.seoul_competition.senior_jobtraining.domain.education.entity.Education;
 import java.text.DecimalFormat;
+import java.time.LocalDate;
 import lombok.Getter;
 
 
@@ -14,10 +16,14 @@ public class EducationResponse {
 
   private String price;
   private Integer capacity;
-  private String registerStart;
-  private String registerEnd;
-  private String educationStart;
-  private String educationEnd;
+  @JsonFormat(pattern = "yyyy.MM.dd")
+  private LocalDate registerStart;
+  @JsonFormat(pattern = "yyyy.MM.dd")
+  private LocalDate registerEnd;
+  @JsonFormat(pattern = "yyyy.MM.dd")
+  private LocalDate educationStart;
+  @JsonFormat(pattern = "yyyy.MM.dd")
+  private LocalDate educationEnd;
   private String url;
   private Long hits;
   private int reviewsCount;

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/entity/Education.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/entity/Education.java
@@ -34,7 +34,7 @@ public class Education {
   private Long id;
 
   @Column(name = "price", nullable = false)
-  private String price;
+  private Integer price;
   @Column(name = "capacity", nullable = false)
   private int capacity;
   @Column(name = "name", nullable = false)
@@ -66,7 +66,7 @@ public class Education {
   private int originId;
 
   @Builder
-  public Education(String name, String status, String url, String price, int capacity,
+  public Education(String name, String status, String url, Integer price, int capacity,
       String registerStart, String registerEnd, String educationStart,
       String educationEnd, Long hits, int originId) {
 

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/entity/Education.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/entity/Education.java
@@ -36,7 +36,7 @@ public class Education {
   @Column(name = "price", nullable = false)
   private Integer price;
   @Column(name = "capacity", nullable = false)
-  private int capacity;
+  private Integer capacity;
   @Column(name = "name", nullable = false)
   private String name;
   @Column(name = "status", nullable = false)
@@ -66,7 +66,7 @@ public class Education {
   private int originId;
 
   @Builder
-  public Education(String name, String status, String url, Integer price, int capacity,
+  public Education(String name, String status, String url, Integer price, Integer capacity,
       String registerStart, String registerEnd, String educationStart,
       String educationEnd, Long hits, int originId) {
 

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/entity/Education.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/entity/Education.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.lang.String;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,13 +45,13 @@ public class Education {
   @Column(name = "url", nullable = false)
   private String url;
   @Column(name = "register_start", nullable = false)
-  private String registerStart;
+  private LocalDate registerStart;
   @Column(name = "register_end", nullable = false)
-  private String registerEnd;
+  private LocalDate registerEnd;
   @Column(name = "education_start", nullable = false)
-  private String educationStart;
+  private LocalDate educationStart;
   @Column(name = "education_end", nullable = false)
-  private String educationEnd;
+  private LocalDate educationEnd;
 
   @Column(name = "hits", nullable = false)
   private Long hits;
@@ -67,8 +68,8 @@ public class Education {
 
   @Builder
   public Education(String name, String status, String url, Integer price, Integer capacity,
-      String registerStart, String registerEnd, String educationStart,
-      String educationEnd, Long hits, int originId) {
+      LocalDate registerStart, LocalDate registerEnd, LocalDate educationStart,
+      LocalDate educationEnd, Long hits, int originId) {
 
     this.name = name;
     this.status = status;


### PR DESCRIPTION
## 🔥 Related Issue

close: #95 

## 📝 Description

Education Entity의 컬럼들의 타입이, 성능저하 및 쿼리문 작성 난이도 상승 등으로 인한 문제로, API스팩은 같게 하면서, 타입만 변경하였습니다.

## ⭐️ Review

Jpa에서 null 값이 들어갈 수 없는 컬럼은 0이나 오류가 날 수 있어, wrapper class를 선호하고, String 조회는 속도가 느립니다.(하지만 그렇게 큰 차이는 아니기에, 필요하다면 써도 상관없습니다)