### PR TITLE
Feature/#77 교육 필터링 기능 구현

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/EducationService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/EducationService.java
@@ -3,7 +3,6 @@ package com.seoul_competition.senior_jobtraining.domain.education.application;
 import static com.seoul_competition.senior_jobtraining.domain.education.entity.QEducation.education;
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.dsl.Expressions;
 import com.seoul_competition.senior_jobtraining.domain.education.application.convenience.EducationFiftyService;
 import com.seoul_competition.senior_jobtraining.domain.education.application.convenience.EducationSeniorService;
 import com.seoul_competition.senior_jobtraining.domain.education.dao.EducationRepository;
@@ -46,21 +45,17 @@ public class EducationService {
       builder.and(education.status.eq(reqDto.status()));
     }
     if (reqDto.minPrice() != null) {
-      builder.and(Expressions
-          .numberPath(Integer.class, "education.price")
-          .gt(reqDto.minPrice()));
+      builder.and(education.price.goe(reqDto.minPrice()));
     }
     if (reqDto.maxPrice() != null) {
-      builder.and(Expressions
-          .numberPath(Integer.class, "education.price")
-          .lt(reqDto.maxPrice()));
+      builder.and(education.price.loe(reqDto.maxPrice()));
     }
-//    if (reqDto.startDate() != null) {
-//      builder.and(education.educationStart.gt(reqDto.startDate()));
-//    }
-//    if (reqDto.endDate() != null) {
-//      builder.and(education.educationEnd.lt(reqDto.endDate()));
-//    }
+    if (reqDto.startDate() != null) {
+      builder.and(education.educationStart.goe(reqDto.startDate()));
+    }
+    if (reqDto.endDate() != null) {
+      builder.and(education.educationEnd.loe(reqDto.endDate()));
+    }
 
     Page<Education> educationPage = educationRepository.findAll(builder, pageable);
 

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/request/EducationSearchReqDto.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/request/EducationSearchReqDto.java
@@ -1,10 +1,12 @@
 package com.seoul_competition.senior_jobtraining.domain.education.dto.request;
 
+import java.time.LocalDate;
+
 public record EducationSearchReqDto(
     String name,
     String status,
-    String startDate,
-    String endDate,
+    LocalDate startDate,
+    LocalDate endDate,
     Integer minPrice,
     Integer maxPrice) {
 


### PR DESCRIPTION
## 🔥 Related Issue

close: #77 

## 📝 Description

교육 검색에 관해, 이름, 상태, 교육 시작일, 교육 끝나는 날, 최소 가격, 최대 가격 에 대하여 동적 쿼리로 구현을 하였습니다.

## ⭐️ Review

중간에 Entity 타입을 String으로 줘서, 문제 된 점이 많아, 먼저 리팩토링부터 하였습니다.

 queryDsl을 사용하는 DAO를 직접 만드는 방식이 아닌, `QuerydslPredicateExecutor`를 사용하였습니다.
join이 없는 단순 동적 쿼리문이라서 편하게 하기 위해서였습니다.

하지만, 해당 문법을 쓰면, where절로 동적쿼리 작성은 스팩상 불가능 하여, `BooleanBuilder`를 써야했는데, 이걸 몰라 애먹었습니다..😅