### PR TITLE
refactor: 챗봇 관련 api url 수정

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/chat/api/ChatHistoryController.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/chat/api/ChatHistoryController.java
@@ -27,15 +27,15 @@ public class ChatHistoryController {
 
   private final ChatHistoryService chatHistoryService;
   private final WebClient webClient;
+  private static final String API_URL = "http://fastapi:8000/chat/answer";
 
   @Operation(summary = "채팅 응답 기록", description = "채팅 응답을 받습니다.")
   @PostMapping("/question")
   public Mono<ResponseEntity<ChatQuestionResDto>> chatAnswer(
       @RequestBody @Valid ChatQuestionReqDto reqDto) {
-    String apiUrl = "http://localhost:8000/chat/answer";  // FastAPI 서버의 URL
 
     return webClient.post()
-        .uri(apiUrl)
+        .uri(API_URL)
         .body(BodyInserters.fromValue(reqDto))
         .retrieve()
         .bodyToMono(ChatAnswerResDto.class)


### PR DESCRIPTION
## 🔥 Related Issue

close: #118 

## 📝 Description

- fast api와 통신하는 url을 변경해주었습니다.
- docker를 이용해서 같은 네트워크 안에서 통신을 하기 위해서는 http://localhost 가 아니라 http://`컨테이너 이름(fast_api)`을 적용해야 했습니다.

## ⭐️ Review
- 정상 작동하는 것을 확인했습니다.
<img width="552" alt="image" src="https://github.com/beginner0107/seoul-competition-backend/assets/81161819/9cff9593-7afb-4c65-adef-400be154885b">
