### PR TITLE
Feature/#120 교육정보 추천 기능구현

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/EducationService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/application/EducationService.java
@@ -10,6 +10,9 @@ import com.seoul_competition.senior_jobtraining.domain.education.dto.request.Edu
 import com.seoul_competition.senior_jobtraining.domain.education.dto.response.EducationDetailResDto;
 import com.seoul_competition.senior_jobtraining.domain.education.dto.response.EducationListPageResponse;
 import com.seoul_competition.senior_jobtraining.domain.education.dto.response.EducationResponse;
+import com.seoul_competition.senior_jobtraining.domain.education.dto.response.RecommendationEducation;
+import com.seoul_competition.senior_jobtraining.domain.education.dto.response.RecommendationEducationsDto;
+import com.seoul_competition.senior_jobtraining.domain.education.dto.response.RecommendationEducationsResponse;
 import com.seoul_competition.senior_jobtraining.domain.education.entity.Education;
 import com.seoul_competition.senior_jobtraining.global.error.ErrorCode;
 import com.seoul_competition.senior_jobtraining.global.error.exception.BusinessException;
@@ -18,6 +21,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -26,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Getter
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class EducationService {
 
@@ -82,10 +87,10 @@ public class EducationService {
   }
 
   @Transactional
-  public EducationDetailResDto findById(Long id,Boolean user) {
+  public EducationDetailResDto findById(Long id, Boolean user) {
     Education findEducation = educationRepository.findById(id).get();
     findEducation.hitsPlus();
-    return new EducationDetailResDto(findEducation,user);
+    return new EducationDetailResDto(findEducation, user);
   }
 
 
@@ -118,4 +123,13 @@ public class EducationService {
     }
   }
 
+  public RecommendationEducationsResponse findRecommendedTraining(
+      List<RecommendationEducation> results) {
+    List<Long> ids = results.stream()
+        .map(RecommendationEducation::from)
+        .collect(Collectors.toList());
+    List<RecommendationEducationsDto> recommendationEducationsDto = educationRepository.findByIdIn(
+        ids);
+    return RecommendationEducationsResponse.of(recommendationEducationsDto);
+  }
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dao/EducationRepository.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dao/EducationRepository.java
@@ -1,10 +1,13 @@
 package com.seoul_competition.senior_jobtraining.domain.education.dao;
 
+import com.seoul_competition.senior_jobtraining.domain.education.dto.response.RecommendationEducationsDto;
 import com.seoul_competition.senior_jobtraining.domain.education.entity.Education;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 
 public interface EducationRepository extends JpaRepository<Education, Long>,
@@ -13,5 +16,11 @@ public interface EducationRepository extends JpaRepository<Education, Long>,
   Page<Education> findByNameContainingOrderByStatusDesc(Pageable pageable, String name);
 
   Optional<Education> findByOriginId(Long originId);
+
+  @Query("SELECT new com.seoul_competition.senior_jobtraining.domain.education.dto.response"
+      + ".RecommendationEducationsDto(e.id, e.name, e.status, e.capacity, e.registerStart"
+      + ", e.registerEnd, e.educationStart, e.educationEnd, e.url, e.hits) "
+      + "FROM Education e WHERE e.id IN :ids")
+  List<RecommendationEducationsDto> findByIdIn(List<Long> ids);
 
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/request/OriginIdRequest.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/request/OriginIdRequest.java
@@ -1,0 +1,10 @@
+package com.seoul_competition.senior_jobtraining.domain.education.dto.request;
+
+public record OriginIdRequest(
+    Long originId
+) {
+
+  public static OriginIdRequest of(Long originId) {
+    return new OriginIdRequest(originId);
+  }
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/request/SearchKeywordRequest.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/request/SearchKeywordRequest.java
@@ -1,0 +1,10 @@
+package com.seoul_competition.senior_jobtraining.domain.education.dto.request;
+
+public record SearchKeywordRequest(
+    String searchKeyword
+) {
+
+  public static SearchKeywordRequest of(String searchKeyword) {
+    return new SearchKeywordRequest(searchKeyword);
+  }
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/RecommendationEducation.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/RecommendationEducation.java
@@ -1,0 +1,10 @@
+package com.seoul_competition.senior_jobtraining.domain.education.dto.response;
+
+public record RecommendationEducation(
+    int id
+) {
+
+  public static Long from(RecommendationEducation item) {
+    return (long) item.id;
+  }
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/RecommendationEducations.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/RecommendationEducations.java
@@ -1,0 +1,9 @@
+package com.seoul_competition.senior_jobtraining.domain.education.dto.response;
+
+import java.util.List;
+
+public record RecommendationEducations(
+    List<RecommendationEducation> results
+) {
+
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/RecommendationEducationsDto.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/RecommendationEducationsDto.java
@@ -1,0 +1,27 @@
+package com.seoul_competition.senior_jobtraining.domain.education.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RecommendationEducationsDto {
+
+  private Long id;
+  private String name;
+  private String status;
+  private Integer capacity;
+  @JsonFormat(pattern = "yyyy.MM.dd")
+  private LocalDate registerStart;
+  @JsonFormat(pattern = "yyyy.MM.dd")
+  private LocalDate registerEnd;
+  @JsonFormat(pattern = "yyyy.MM.dd")
+  private LocalDate educationStart;
+  @JsonFormat(pattern = "yyyy.MM.dd")
+  private LocalDate educationEnd;
+  private String url;
+  private Long hits;
+
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/RecommendationEducationsResponse.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/response/RecommendationEducationsResponse.java
@@ -1,0 +1,11 @@
+package com.seoul_competition.senior_jobtraining.domain.education.dto.response;
+
+import java.util.List;
+
+public record RecommendationEducationsResponse(List<RecommendationEducationsDto> data) {
+
+  public static RecommendationEducationsResponse of(
+      List<RecommendationEducationsDto> recommendationEducationsDto) {
+    return new RecommendationEducationsResponse(recommendationEducationsDto);
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #120 

## 📝 Description

- fast api와 통신하여, 추천 게시글 id를 가져왔습니다.
- 일치하는 게시글 id를 찾아 추천 게시글을 프론트에 전달하는 기능을 구현하였습니다.
<img width="472" alt="image" src="https://github.com/beginner0107/seoul-competition-backend/assets/81161819/9c2b4df0-1fe1-493d-88ce-610071747123">

## ⭐️ Review
- 좀 해맸는데, 구현하고 뿌듯했습니다. 