### PR TITLE
fix: Dto의 필드명 변경 originId -> educationId

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/request/EducationRequest.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dto/request/EducationRequest.java
@@ -1,7 +1,7 @@
 package com.seoul_competition.senior_jobtraining.domain.education.dto.request;
 
 public record EducationRequest(
-    Long originId
+    Long educationId
 ) {
 
   public static EducationRequest of(Long educationId) {


### PR DESCRIPTION
## 🔥 Related Issue

close: #126 

## 📝 Description

- Dto의 필드 명이 originId로 되어있어 fast api에서 .으로 접근했을 때 찾지 못하는 부분이 원인인거 같습니다.
