### PR TITLE
Feature/#130 챗봇 기록과 교육정보를 넘기는 기능을 구현

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/chat/dao/ChatHistoryRepository.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/chat/dao/ChatHistoryRepository.java
@@ -1,8 +1,12 @@
 package com.seoul_competition.senior_jobtraining.domain.chat.dao;
 
 import com.seoul_competition.senior_jobtraining.domain.chat.entity.ChatHistory;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatHistoryRepository extends JpaRepository<ChatHistory, Long> {
 
+  List<ChatHistory> findByCreatedAtBetween(LocalDateTime startDate,
+      LocalDateTime endDate);
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/chat/entity/ChatHistory.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/chat/entity/ChatHistory.java
@@ -31,7 +31,7 @@ public class ChatHistory {
 
   private String answer;
 
-  private boolean feedback;
+  private Boolean feedback = null;
 
   @CreatedDate
   @Column(nullable = false)

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dao/EducationRepository.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/education/dao/EducationRepository.java
@@ -2,6 +2,7 @@ package com.seoul_competition.senior_jobtraining.domain.education.dao;
 
 import com.seoul_competition.senior_jobtraining.domain.education.dto.response.RecommendationEducationsDto;
 import com.seoul_competition.senior_jobtraining.domain.education.entity.Education;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -22,5 +23,7 @@ public interface EducationRepository extends JpaRepository<Education, Long>,
       + ", e.registerEnd, e.educationStart, e.educationEnd, e.url, e.hits) "
       + "FROM Education e WHERE e.id IN :ids")
   List<RecommendationEducationsDto> findByIdIn(List<Long> ids);
+
+  List<Education> findByCreatedAtBetween(LocalDateTime startDate, LocalDateTime endDate);
 
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/global/scheduler/EducationAndChatInfoScheduler.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/global/scheduler/EducationAndChatInfoScheduler.java
@@ -1,0 +1,62 @@
+package com.seoul_competition.senior_jobtraining.global.scheduler;
+
+import com.seoul_competition.senior_jobtraining.domain.chat.dao.ChatHistoryRepository;
+import com.seoul_competition.senior_jobtraining.domain.chat.entity.ChatHistory;
+import com.seoul_competition.senior_jobtraining.domain.education.dao.EducationRepository;
+import com.seoul_competition.senior_jobtraining.domain.education.entity.Education;
+import com.seoul_competition.senior_jobtraining.global.scheduler.dto.ChatHistoryMonthReqDto;
+import com.seoul_competition.senior_jobtraining.global.scheduler.dto.EducationMonthReqDto;
+import com.seoul_competition.senior_jobtraining.global.scheduler.dto.ModelUpdateData;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+public class EducationAndChatInfoScheduler {
+
+  private final EducationRepository educationRepository;
+  private final ChatHistoryRepository chatHistoryRepository;
+  private final WebClient webClient;
+  private final String EDUCATION_AND_CHAT_INFO_URL = "http://fastapi:8000/model";
+
+  @Scheduled(cron = "0 0 4 L * ?")
+  public void sendEduAndChatInfo() {
+    LocalDate currentDate = LocalDate.now();
+    LocalDate lastDayOfMonth = currentDate.with(TemporalAdjusters.lastDayOfMonth());
+    LocalDate firstDayOfMonth = lastDayOfMonth.withDayOfMonth(1);
+
+    LocalDateTime startDateTime = firstDayOfMonth.atStartOfDay();
+    LocalDateTime endDateTime = lastDayOfMonth.atTime(LocalTime.MAX);
+
+    List<EducationMonthReqDto> educations = new ArrayList<>();
+    for (Education education : educationRepository.findByCreatedAtBetween(
+        startDateTime, endDateTime)) {
+      EducationMonthReqDto educationMonthReqDto = EducationMonthReqDto.from(education);
+      educations.add(educationMonthReqDto);
+    }
+
+    List<ChatHistoryMonthReqDto> chatHistories = new ArrayList<>();
+    for (ChatHistory chatHistory : chatHistoryRepository.findByCreatedAtBetween(
+        startDateTime, endDateTime)) {
+      ChatHistoryMonthReqDto chatHistoryMonthReqDto = ChatHistoryMonthReqDto.from(chatHistory);
+      chatHistories.add(chatHistoryMonthReqDto);
+    }
+
+    ModelUpdateData data = ModelUpdateData.of(educations, chatHistories);
+
+    webClient.post()
+        .uri(EDUCATION_AND_CHAT_INFO_URL)
+        .bodyValue(data)
+        .retrieve()
+        .toBodilessEntity()
+        .block();
+  }
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/global/scheduler/dto/ChatHistoryMonthReqDto.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/global/scheduler/dto/ChatHistoryMonthReqDto.java
@@ -1,0 +1,18 @@
+package com.seoul_competition.senior_jobtraining.global.scheduler.dto;
+
+import com.seoul_competition.senior_jobtraining.domain.chat.entity.ChatHistory;
+import java.time.LocalDateTime;
+
+public record ChatHistoryMonthReqDto(
+    Long id,
+    String question,
+    String answer,
+    Boolean feedback,
+    LocalDateTime createAt
+) {
+
+  public static ChatHistoryMonthReqDto from(ChatHistory chatHistory) {
+    return new ChatHistoryMonthReqDto(chatHistory.getId(), chatHistory.getQuestion(),
+        chatHistory.getAnswer(), chatHistory.getFeedback(), chatHistory.getCreatedAt());
+  }
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/global/scheduler/dto/EducationMonthReqDto.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/global/scheduler/dto/EducationMonthReqDto.java
@@ -1,0 +1,27 @@
+package com.seoul_competition.senior_jobtraining.global.scheduler.dto;
+
+import com.seoul_competition.senior_jobtraining.domain.education.entity.Education;
+
+public record EducationMonthReqDto(
+    long id,
+    String name,
+    int price,
+    String status,
+    int capacity,
+    String registerStart,
+    String registerEnd,
+    String educationsStart,
+    String educationEnd,
+    String url,
+    Long hits
+) {
+
+  public static EducationMonthReqDto from(Education education) {
+    return new EducationMonthReqDto(education.getId(), education.getName(),
+        education.getPrice(), education.getStatus(), education.getCapacity(),
+        education.getRegisterStart().toString(), education.getRegisterEnd().toString(),
+        education.getEducationStart().toString(), education.getEducationEnd().toString(),
+        education.getUrl(), education.getHits()
+    );
+  }
+}

--- a/src/main/java/com/seoul_competition/senior_jobtraining/global/scheduler/dto/ModelUpdateData.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/global/scheduler/dto/ModelUpdateData.java
@@ -1,0 +1,14 @@
+package com.seoul_competition.senior_jobtraining.global.scheduler.dto;
+
+import java.util.List;
+
+public record ModelUpdateData(
+    List<EducationMonthReqDto> educations,
+    List<ChatHistoryMonthReqDto> chatHistories
+) {
+
+  public static ModelUpdateData of(List<EducationMonthReqDto> educations,
+      List<ChatHistoryMonthReqDto> chatHistories) {
+    return new ModelUpdateData(educations, chatHistories);
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #130 

## 📝 Description
- 추가된 교육 데이터와 교육 정보를 넘기는 기능을 구현했습니다.
<img width="444" alt="image" src="https://github.com/beginner0107/seoul-competition-backend/assets/81161819/ceafddbd-6e12-4427-8565-5f57b449efea">
<img width="576" alt="image" src="https://github.com/beginner0107/seoul-competition-backend/assets/81161819/2bae0fa5-2836-41c9-968b-ae616296f057">


## ⭐️ Review
- 초기 교육 데이터들의 생성일자가 2023.05 가 되어 5월 말에 만 건의 교육 데이터가 전부 넘어가게 되는 문제가 있습니다.
- 챗봇 기록같은 경우에는 문제가 없습니다. feedback은 위에서도 보셨듯이, null / false / true 이런식으로 넘어가게 됩니다. 