### PR TITLE
fix: 교육리뷰 댓글 수정 시 닉네임도 수정할 수 있게 변경

### DIFF
--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/review/application/ReviewService.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/review/application/ReviewService.java
@@ -40,7 +40,7 @@ public class ReviewService {
 
     review.checkPassword(reqDto.password());
 
-    review.update(reqDto.content());
+    review.update(reqDto.nickname(), reqDto.content());
   }
 
   @Transactional

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/review/dto/request/ReviewUpdateReqDto.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/review/dto/request/ReviewUpdateReqDto.java
@@ -1,11 +1,11 @@
 package com.seoul_competition.senior_jobtraining.domain.review.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public record ReviewUpdateReqDto(
+    @NotBlank(message = "닉네임을 입력해주세요.") String nickname,
     @NotBlank(message = "비밀번호를 입력해주세요.") String password,
     @NotBlank(message = "내용이 비어있습니다.") String content
-    ) {
+) {
 
 }

--- a/src/main/java/com/seoul_competition/senior_jobtraining/domain/review/entity/Review.java
+++ b/src/main/java/com/seoul_competition/senior_jobtraining/domain/review/entity/Review.java
@@ -65,7 +65,8 @@ public class Review {
     }
   }
 
-  public void update(String content) {
+  public void update(String nickname, String content) {
+    this.nickname = nickname;
     this.content = content;
   }
 }


### PR DESCRIPTION
## 🔥 Related Issue

close: #141 

## 📝 Description
- 교육리뷰 댓글 수정 시 닉네임도 수정할 수 있게 변경하였습니다.